### PR TITLE
Refactored config flow

### DIFF
--- a/custom_components/eaton_ups/api.py
+++ b/custom_components/eaton_ups/api.py
@@ -1,11 +1,11 @@
 """API for Eaton UPS."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
+from typing import Any
 
 from pysnmp import hlapi
-
-from homeassistant.config_entries import ConfigEntry
 
 from .const import (
     ATTR_AUTH_KEY,
@@ -44,28 +44,26 @@ _LOGGER = logging.getLogger(__name__)
 class SnmpApi:
     """Provide an api for Eaton UPS."""
 
-    def __init__(self, entry: ConfigEntry) -> None:
+    def __init__(self, data: Mapping[str, Any]) -> None:
         """Init the SnmpApi."""
         self._target = hlapi.UdpTransportTarget(
             (
-                entry.data.get(ATTR_HOST),
-                entry.data.get(ATTR_PORT, SNMP_PORT_DEFAULT),
+                data.get(ATTR_HOST),
+                data.get(ATTR_PORT, SNMP_PORT_DEFAULT),
             ),
             10,
         )
 
-        self._version = entry.data.get(ATTR_VERSION)
+        self._version = data.get(ATTR_VERSION)
         if self._version == SnmpVersion.V1:
-            self._credentials = hlapi.CommunityData(
-                entry.data.get(ATTR_COMMUNITY), mpModel=0
-            )
+            self._credentials = hlapi.CommunityData(data.get(ATTR_COMMUNITY), mpModel=0)
         elif self._version == SnmpVersion.V3:
             self._credentials = hlapi.UsmUserData(
-                entry.data.get(ATTR_USERNAME),
-                entry.data.get(ATTR_AUTH_KEY),
-                entry.data.get(ATTR_PRIV_KEY),
-                AUTH_MAP.get(entry.data.get(ATTR_AUTH_PROTOCOL, AuthProtocol.NO_AUTH)),
-                PRIV_MAP.get(entry.data.get(ATTR_PRIV_PROTOCOL, PrivProtocol.NO_PRIV)),
+                data.get(ATTR_USERNAME),
+                data.get(ATTR_AUTH_KEY),
+                data.get(ATTR_PRIV_KEY),
+                AUTH_MAP.get(data.get(ATTR_AUTH_PROTOCOL, AuthProtocol.NO_AUTH)),
+                PRIV_MAP.get(data.get(ATTR_PRIV_PROTOCOL, PrivProtocol.NO_PRIV)),
             )
 
     @staticmethod

--- a/custom_components/eaton_ups/config_flow.py
+++ b/custom_components/eaton_ups/config_flow.py
@@ -17,18 +17,19 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.typing import ConfigType
 
+from .api import SnmpApi
 from .const import (
     ATTR_AUTH_KEY,
     ATTR_AUTH_PROTOCOL,
     ATTR_COMMUNITY,
     ATTR_HOST,
-    ATTR_NAME,
     ATTR_PORT,
     ATTR_PRIV_KEY,
     ATTR_PRIV_PROTOCOL,
     ATTR_USERNAME,
     ATTR_VERSION,
     DOMAIN,
+    SNMP_OID_IDENT_PRODUCT_NAME,
     SNMP_PORT_DEFAULT,
     AuthProtocol,
     PrivProtocol,
@@ -40,7 +41,6 @@ def get_host_schema_config(data: ConfigType) -> Schema:
     """Return the host schema for config flow."""
     return vol.Schema(
         {
-            vol.Required(ATTR_NAME, default=data.get(ATTR_NAME)): cv.string,
             vol.Required(ATTR_HOST, default=data.get(ATTR_HOST)): cv.string,
             vol.Required(
                 ATTR_PORT, default=data.get(ATTR_PORT, SNMP_PORT_DEFAULT)
@@ -152,7 +152,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.data.update(v1_input)
 
-        return self.async_create_entry(title=self.data[ATTR_NAME], data=self.data)
+        api = SnmpApi(self.data)
+        result = api.get([SNMP_OID_IDENT_PRODUCT_NAME])
+
+        return self.async_create_entry(
+            title=result.get(SNMP_OID_IDENT_PRODUCT_NAME), data=self.data
+        )
 
     async def async_step_v3(self, v3_input: ConfigType | None = None) -> FlowResult:
         """Handle the v3 step."""
@@ -163,7 +168,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.data.update(v3_input)
 
-        return self.async_create_entry(title=self.data[ATTR_NAME], data=self.data)
+        api = SnmpApi(self.data)
+        result = api.get([SNMP_OID_IDENT_PRODUCT_NAME])
+
+        return self.async_create_entry(
+            title=result.get(SNMP_OID_IDENT_PRODUCT_NAME), data=self.data
+        )
 
     @staticmethod
     @callback
@@ -210,7 +220,14 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         self.data.update(v1_input)
 
-        self.hass.config_entries.async_update_entry(self.config_entry, data=self.data)
+        api = SnmpApi(self.config_entry.data)
+        result = api.get([SNMP_OID_IDENT_PRODUCT_NAME])
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            title=result.get(SNMP_OID_IDENT_PRODUCT_NAME),
+            data=self.data,
+        )
 
         return self.async_create_entry(title="", data={})
 
@@ -223,7 +240,14 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         self.data.update(v3_input)
 
-        self.hass.config_entries.async_update_entry(self.config_entry, data=self.data)
+        api = SnmpApi(self.config_entry.data)
+        result = api.get([SNMP_OID_IDENT_PRODUCT_NAME])
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            title=result.get(SNMP_OID_IDENT_PRODUCT_NAME),
+            data=self.data,
+        )
 
         return self.async_create_entry(title="", data={})
 

--- a/custom_components/eaton_ups/const.py
+++ b/custom_components/eaton_ups/const.py
@@ -14,7 +14,6 @@ PLATFORMS = [
     Platform.SENSOR,
 ]
 
-ATTR_NAME = "name"
 ATTR_HOST = "host"
 ATTR_PORT = "port"
 ATTR_VERSION = "version"

--- a/custom_components/eaton_ups/coordinator.py
+++ b/custom_components/eaton_ups/coordinator.py
@@ -59,7 +59,7 @@ class SnmpCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=timedelta(seconds=60),
         )
-        self._api = SnmpApi(entry)
+        self._api = SnmpApi(entry.data)
 
     def _update_data(self) -> dict:
         """Fetch the latest data from the source."""


### PR DESCRIPTION
Refactored to avoid manual title input but use product name from configured device. The name will be fetched through SNMP.

This should answer and avoid problems like in https://github.com/jaroschek/home-assistant-eaton-ups/issues/2