### PR TITLE
Fix InputStatus value error: add unknown value (0)

### DIFF
--- a/custom_components/eaton_ups/const.py
+++ b/custom_components/eaton_ups/const.py
@@ -146,6 +146,7 @@ class InputSource(Enum):
 class InputStatus(Enum):
     """Values for Inoput Status."""
 
+    unknown = 0
     bad = 1
     good = 2
 


### PR DESCRIPTION
This prevented the integration from updating values.

Closes jaroschek/home-assistant-eaton-ups#41