### PR TITLE
Fix SNMPv3 credential handling

### DIFF
--- a/custom_components/eaton_ups/__init__.py
+++ b/custom_components/eaton_ups/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from homeassistant.components.snmp import async_get_snmp_engine
+from pysnmp.hlapi.asyncio import SnmpEngine
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
@@ -14,8 +15,8 @@ from .coordinator import SnmpCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Eaton UPS from a config entry."""
-    snmpEngine = await async_get_snmp_engine(hass)
-    api = SnmpApi(snmpEngine)
+    snmp_engine = await hass.async_add_executor_job(SnmpEngine)
+    api = SnmpApi(snmp_engine)
     await api.setup(entry)
     coordinator = SnmpCoordinator(hass=hass, api=api)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/eaton_ups/api.py
+++ b/custom_components/eaton_ups/api.py
@@ -89,7 +89,7 @@ class SnmpApi:
             self._credentials = hlapi.UsmUserData(
                 entry.data.get(ATTR_USERNAME),
                 entry.data.get(ATTR_AUTH_KEY),
-                entry.data.get(ATTR_PRIV_KEY),
+                entry.data.get(ATTR_PRIV_KEY) or None,
                 AUTH_MAP.get(entry.data.get(ATTR_AUTH_PROTOCOL, AuthProtocol.NO_AUTH)),
                 PRIV_MAP.get(entry.data.get(ATTR_PRIV_PROTOCOL, PrivProtocol.NO_PRIV)),
             )


### PR DESCRIPTION
## Summary

- Create a dedicated PySNMP engine for each config entry.
- Normalize an empty SNMPv3 privacy key to `None`.

## Problem

Home Assistant's shared SNMP engine can retain USM credentials by security
name. When multiple devices use the same SNMPv3 username with different
authentication or privacy settings, their credentials can collide.

Additionally, the config flow stores the optional privacy key as an empty
string for AuthNoPriv configurations. Current PySNMP releases validate that
empty string as a privacy key and reject it for being too short, even though
privacy is disabled.

## Testing

Tested with:

- Home Assistant 2026.8.3
- PySNMP 7.1.27
- Eaton 9PX 6000 with a Network-MS card
- SNMPv3 using MD5 and AuthNoPriv
- Another Eaton integration using the same username with SHA/AES AuthPriv

Before this change, setup failed with a PySNMP USM `WrongValueError`.
Afterward, the config entry loads and its entities update normally.

`python3 -m compileall -q custom_components` and `git diff --check` both pass.
