### PR TITLE
Treat an empty-string OID value as no reading, not a crash

### DIFF
--- a/custom_components/eaton_ups/sensor.py
+++ b/custom_components/eaton_ups/sensor.py
@@ -114,22 +114,29 @@ class SnmpSensorEntity(SnmpEntity, SensorEntity):
     def __init__(self, coordinator: SnmpCoordinator, index: str = "") -> None:
         """Initialize a Eaton UPS sensor."""
         super().__init__(coordinator, index)
-        self._attr_native_value = self.coordinator.data.get(
-            self._value_oid, self._default_value
-        )
-        if self._multiplier is not None:
-            self._attr_native_value *= self._multiplier
+        self._attr_native_value = self._read_value()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = self.coordinator.data.get(
-            self._value_oid, self._default_value
-        )
-        if self._multiplier is not None:
-            self._attr_native_value *= self._multiplier
-
+        self._attr_native_value = self._read_value()
         super().async_write_ha_state()
+
+    def _read_value(self):
+        """Read this sensor's value from the coordinator.
+
+        An OID can come back as an empty string when the UPS has no
+        reading for it yet (observed on the output cumulative energy
+        OID); treat that the same as a missing OID rather than passing
+        '' through as native_value, which HA's numeric sensor state
+        machinery rejects.
+        """
+        value = self.coordinator.data.get(self._value_oid, self._default_value)
+        if value == "":
+            return None
+        if self._multiplier is not None:
+            value *= self._multiplier
+        return value
 
 
 class SnmpBatterySensorEntity(SnmpSensorEntity):
@@ -198,7 +205,7 @@ class SnmpBatteryLastReplacedSensorEntity(SnmpBatterySensorEntity):
                 .replace(tzinfo=get_time_zone(self.coordinator.hass.config.time_zone))
                 .date()
             )
-        except ValueError:
+        except (ValueError, TypeError):
             return None
 
 


### PR DESCRIPTION
## Summary

Some SNMP OIDs (observed on output cumulative energy) can briefly return an empty octet-string instead of a number — e.g. before the UPS has accumulated any reading for that counter. `SnmpApi.cast()` falls through `int -> float -> str` for a value it can't parse numerically, so this ends up stored as the literal string `''` rather than a missing key.

`SnmpSensorEntity` then passed that `''` straight through as `native_value`. For any sensor with a numeric `device_class` (energy, voltage, current, ...), Home Assistant's sensor state machinery tries `int()`/`float()` on it and raises — both when the entity is first added and on every subsequent coordinator update:

```
ValueError: Sensor sensor.server_eaton_5p_1550_output_energy has device class 'energy', state class 'total_increasing' unit 'Wh' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: '' (<class 'str'>)
```

Hit this repeatedly on a Eaton 5P 1550 (output cumulative energy OID), both as a one-time "Error adding entity" at startup and as a recurring "Unexpected error updating listener" on every coordinator refresh after.

## Fix

`SnmpSensorEntity` now treats an empty-string OID value the same as a missing one — `native_value` becomes `None` (a normal "unknown" reading) instead of the unparseable `''`. Refactored the duplicated read logic in `__init__`/`_handle_coordinator_update` into one `_read_value()` helper while at it.

Also widened `SnmpBatteryLastReplacedSensorEntity`'s except clause to catch `TypeError` alongside `ValueError`, since `strptime(None, ...)` raises `TypeError` where `strptime('', ...)` raised `ValueError` — this sensor already handled an empty/invalid date string as "unknown", now it does the same for a `None` value consistently.

## Test plan

No test suite exists in this repo. Verified locally:
- `python3 -m py_compile` on the changed file.
- Isolated reproduction of `_read_value()`'s branching logic (empty string -> `None`, missing OID -> default, normal value passes through, multiplier still applies) — all as expected.
- Confirmed `datetime.strptime(None, "%m/%d/%Y")` raises `TypeError`, now caught by the widened except clause.